### PR TITLE
Use `please-upgrade-node` lib to prevent users to avoid using node ve…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 # Installation
 - `$ npm install -g @djaty/djaty-cli`
 
+### Prerequisites
+We support node version `6.x.x` or higher.
+
 ## SourceMap files
 Upload sourcemap files to allow Djaty to de-obfuscate your JavaScript stack traces
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3547,6 +3547,14 @@
         "pinkie": "^2.0.0"
       }
     },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -3826,6 +3834,11 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mocha": "^3.1.2",
     "natives": "^1.1.6",
     "ora": "3.1.0",
+    "please-upgrade-node": "^3.2.0",
     "reflect-metadata": "^0.1.12",
     "request": "^2.87.0",
     "request-promise": "^4.2.2",
@@ -53,6 +54,9 @@
   "preferGlobal": true,
   "bin": {
     "djaty-cli": "./bin/djaty-cli"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "devDependencies": {},
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+
+// tslint:disable-next-line no-require-imports
+const pkg = require('./../package.json');
+
+// tslint:disable-next-line no-require-imports
+require('please-upgrade-node')(pkg);
+
 import {djaty} from '@djaty/djaty-nodejs';
 import {nodejsAgentConfig} from './config/nodejsAgentConfig';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es3",
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": ["es6"],


### PR DESCRIPTION
…rsion less than 6

- Compile typescript to `es3` to be run on any node version to avoid having SyntaxError
- Add `Prerequisites` to readme file